### PR TITLE
Convert BoolOps to a tree of BinOps when they have more than 2 children.

### DIFF
--- a/src/stationeers_pytrapic/compile_pass.py
+++ b/src/stationeers_pytrapic/compile_pass.py
@@ -411,6 +411,36 @@ class CompilerPassFindNames(CompilerPass):
             self.data.add_name(node)
 
 
+class CompilerPassBoolOpToBinOp(CompilerPass):
+    def handle_node(self, node: astroid.NodeNG):
+        pass
+
+    def handle_binop(self, node: astroid.BinOp):
+        def make_node_from_rest(parent_node: astroid.BoolOp, other: tuple[astroid.NodeNG]):
+            node = astroid.BinOp(
+                parent_node.op, 
+                parent_node.lineno, 
+                parent_node.col_offset, 
+                parent_node,
+                end_col_offset=parent_node.end_col_offset,
+                end_lineno=parent_node.end_lineno,
+                )
+            if len(other) == 2:
+                node.postinit(other[0], other[1])
+            else:
+                node.postinit(other[0], handle_binop(node, other[1:]))
+            return node
+
+        children = tuple(node.get_children())
+        for child in children:
+            self._visit_node(child)
+        if not isinstance(node, astroid.BoolOp):
+            return
+        if len(children) <= 2:
+            return
+        node.values = [children[0], make_node_from_rest(node, children[1:])]
+
+
 class CompilerPassCheckConstValue(CompilerPass):
     def handle_module(self, node: astroid.NodeNG):
         for child in node.get_children():

--- a/src/stationeers_pytrapic/compile_pass.py
+++ b/src/stationeers_pytrapic/compile_pass.py
@@ -428,7 +428,7 @@ class CompilerPassBoolOpToBinOp(CompilerPass):
             if len(other) == 2:
                 node.postinit(other[0], other[1])
             else:
-                node.postinit(other[0], handle_binop(node, other[1:]))
+                node.postinit(other[0], make_node_from_rest(node, other[1:]))
             return node
 
         children = tuple(node.get_children())

--- a/src/stationeers_pytrapic/compiler.py
+++ b/src/stationeers_pytrapic/compiler.py
@@ -36,6 +36,7 @@ class Compiler:
     def __init__(self, options: CompileOptions):
         self.passes = [
             CompilerPassSetModuleNames,
+            CompilerPassBoolOpToBinOp,
             CompilerPassSetNodeData,
             CompilerPassCheckConstValue,
             CompilerPassCheckUsed,

--- a/test/cases/bool_ops_multiple.compact.ref
+++ b/test/cases/bool_ops_multiple.compact.ref
@@ -1,0 +1,17 @@
+lb r1 -1252983604 6 0
+sgt r0 r1 100
+lb r3 -1252983604 6 0
+slt r2 r3 200
+lb r5 -1252983604 5 0
+sgt r4 r5 150
+lb r7 -1252983604 5 0
+slt r6 r7 250
+and r8 r4 r6
+and r9 r2 r8
+and r10 r0 r9
+lb r12 -1252983604 5 0
+slt r11 r12 270
+or r13 r10 r11
+sbn 1420719315 123 28 r13
+# registers: 14
+# lines: 15

--- a/test/cases/bool_ops_multiple.py
+++ b/test/cases/bool_ops_multiple.py
@@ -1,0 +1,3 @@
+from stationeers_pytrapic.symbols import *
+
+CondensationChambers[123].On = GasSensors.Temperature.Average > 100 and GasSensors.Temperature.Average < 200 and GasSensors.Pressure.Average > 150 and GasSensors.Pressure.Average < 250 or GasSensors.Pressure.Average < 270

--- a/test/cases/bool_ops_multiple.ref
+++ b/test/cases/bool_ops_multiple.ref
@@ -1,0 +1,17 @@
+lb r1 HASH("StructureGasSensor") Temperature Average
+sgt r0 r1 100
+lb r3 HASH("StructureGasSensor") Temperature Average
+slt r2 r3 200
+lb r5 HASH("StructureGasSensor") Pressure Average
+sgt r4 r5 150
+lb r7 HASH("StructureGasSensor") Pressure Average
+slt r6 r7 250
+and r8 r4 r6
+and r9 r2 r8
+and r10 r0 r9
+lb r12 HASH("StructureGasSensor") Pressure Average
+slt r11 r12 270
+or r13 r10 r11
+sbn HASH("StructureCondensationChamber") 123 On r13
+# registers: 14
+# lines: 15


### PR DESCRIPTION
Expressions like
```python
True and True and False
```
Count as a single BoolOp, and because most code expects these to be BinOps, this breaks things.

This PR adds an additional compile pass that converts those bool ops with more than 2 children to a tree of BinOps that only have 2 children each.