### PR TITLE
Use the stack for function parameters and return values directly, instead of the stack of the db device, which may not have stack memory.

### DIFF
--- a/src/stationeers_pytrapic/compile_pass.py
+++ b/src/stationeers_pytrapic/compile_pass.py
@@ -45,7 +45,7 @@ class FunctionData:
     def has_return_value(self) -> bool:
         return self.node and self.node._ndata.func_has_return_value
 
-    def add_ra_instructions(self):
+    def add_ra_instructions(self, options=None):
         have_calls = False
         have_returns = False
         end_label_pos = None
@@ -63,10 +63,43 @@ class FunctionData:
         if have_calls and have_returns:
             ra = IC10Register("ra", code_expr="ra")
             indent = self.code[0].indent + 1
-            self.code.insert(1, IC10Instruction("push", [ra], indent=indent))
-            self.code.insert(
-                end_label_pos + 2, IC10Instruction("pop", [], ra, indent=indent)
-            )
+
+            if options and options.use_push_pop_functions:
+                # Count leading arg pops (right after the function label at pos 0)
+                n_args = next(
+                    (i for i, instr in enumerate(self.code[1:])
+                     if not (instr.op == "pop" and instr.output is not None)),
+                    len(self.code[1:])
+                )
+
+                end_name = name + "end"
+
+                # Every exit point — 'j {name}end' (early return) or '{name}end:' (normal
+                # path) — needs 'pop ra' before its preceding return-value push, or before
+                # the exit point itself for bare/non-returning exits.
+                exit_points = [
+                    i for i, instr in enumerate(self.code)
+                    if (instr.op == "j" and instr.inputs and str(instr.inputs[0].value) == end_name)
+                    or instr.op == (end_name + ":")
+                ]
+                pop_ra_positions = [
+                    pos - 1 if pos > 0 and self.code[pos - 1].op == "push" else pos
+                    for pos in exit_points
+                ]
+
+                # Collect all inserts and apply highest-index first so earlier indices
+                # remain valid without adjustment.
+                all_inserts = (
+                    [(1 + n_args, IC10Instruction("push", [ra], indent=indent))]
+                    + [(pos, IC10Instruction("pop", [], ra, indent=indent)) for pos in set(pop_ra_positions)]
+                )
+                for pos, instr in sorted(all_inserts, key=lambda x: x[0], reverse=True):
+                    self.code.insert(pos, instr)
+            else:
+                self.code.insert(1, IC10Instruction("push", [ra], indent=indent))
+                self.code.insert(
+                    end_label_pos + 2, IC10Instruction("pop", [], ra, indent=indent)
+                )
 
 
 @dataclass
@@ -78,6 +111,7 @@ class CompileOptions:
     append_version: bool = True
     compact: bool = False
     tail_call_optimization: bool = False
+    use_push_pop_functions: bool = False
 
 
 @dataclass

--- a/src/stationeers_pytrapic/generate_code.py
+++ b/src/stationeers_pytrapic/generate_code.py
@@ -295,8 +295,10 @@ class CompilerPassGenerateCode(CompilerPass):
                     arg,
                 )
             if not do_inline:
-                addr = _RETURN_VALUE_ADDRESS - 1 - i
-                data.add(IC10("put", ["db", addr, d]))
+                if self.data.options.use_push_pop_functions:
+                    data.add(IC10("push", [d]))
+                else:
+                    data.add(IC10("put", ["db", _RETURN_VALUE_ADDRESS - 1 - i, d]))
 
         data.add(IC10("jal", [fname.replace("_", ".")]))
         self.compile_function(self.functions[fname])
@@ -320,7 +322,10 @@ class CompilerPassGenerateCode(CompilerPass):
                         symbol.code_expr = self.get_register_name()
                 else:
                     symbol = self.get_intermediate_symbol(node)
-                data.add_end(IC10("get", ["db", _RETURN_VALUE_ADDRESS], symbol))
+                if self.data.options.use_push_pop_functions:
+                    data.add_end(IC10("pop", [], symbol))
+                else:
+                    data.add_end(IC10("get", ["db", _RETURN_VALUE_ADDRESS], symbol))
                 data.result = symbol
 
     def handle_expr(self, node: nodes.Expr):
@@ -342,7 +347,10 @@ class CompilerPassGenerateCode(CompilerPass):
                 sym_data = self.data.get_sym_data(func_node)
                 data.add(IC10("move", [d], sym_data))
             else:
-                data.add(IC10("put", ["db", _RETURN_VALUE_ADDRESS, d]))
+                if self.data.options.use_push_pop_functions:
+                    data.add(IC10("push", [d]))
+                else:
+                    data.add(IC10("put", ["db", _RETURN_VALUE_ADDRESS, d]))
 
         if node != func_node.body[-1]:
             # only jump to end of function, if return is not the last statement
@@ -450,18 +458,15 @@ class CompilerPassGenerateCode(CompilerPass):
                     arg_sym.code_expr = calling_arg
                 func_data.args.append(arg_sym)
         else:
-            for i, arg in enumerate(node.args.args):
+            arg_list = list(reversed(node.args.args)) if self.data.options.use_push_pop_functions else node.args.args
+            for i, arg in enumerate(arg_list):
                 reg = self.get_register_name()
                 sym = self.data.get_sym_data(arg)
                 sym.code_expr = reg
-                data.add(
-                    IC10(
-                        "get",
-                        ["db", _RETURN_VALUE_ADDRESS - 1 - i],
-                        sym,
-                        indent=1,
-                    )
-                )
+                if self.data.options.use_push_pop_functions:
+                    data.add(IC10("pop", [], sym, indent=1))
+                else:
+                    data.add(IC10("get", ["db", _RETURN_VALUE_ADDRESS - 1 - i], sym, indent=1))
                 if arg.name in symbols.__dict__:
                     raise CompilerError(
                         f"Function argument name {arg.name} conflicts with a built-in name",
@@ -1120,7 +1125,7 @@ class CompilerPassGatherCode(CompilerPass):
             if func.is_constexpr:
                 continue
             if fname != "" and func.is_called:
-                func.add_ra_instructions()
+                func.add_ra_instructions(self.data.options)
             if fname == "" or func.is_called:
                 for line in func.code:
                     self.code.append(line)

--- a/test/cases/functions_using_get_set.compact.ref
+++ b/test/cases/functions_using_get_set.compact.ref
@@ -1,0 +1,7 @@
+add r2 1 2
+add r4 r2 3
+move r0 r4
+move r1 r0
+s db Setting r1
+# registers: 4
+# lines: 5

--- a/test/cases/functions_using_get_set.py
+++ b/test/cases/functions_using_get_set.py
@@ -1,0 +1,13 @@
+# pytrapic: no_use_push_pop_functions
+from stationeers_pytrapic.symbols import *
+
+
+def add_two(a, b):
+    return a + b
+
+
+def compute(x, y, z):
+    return add_two(x + y, z)
+
+
+db.Setting = compute(1, 2, 3)

--- a/test/cases/functions_using_get_set.ref
+++ b/test/cases/functions_using_get_set.ref
@@ -1,0 +1,27 @@
+put db 510 1
+put db 509 2
+put db 508 3
+jal compute
+get r0 db 511
+s db Setting r0
+add.two:
+  get r6 db 510
+  get r7 db 509
+  add r8 r6 r7
+  put db 511 r8
+  j ra
+compute:
+  push ra
+  get r1 db 510
+  get r2 db 509
+  get r3 db 508
+  add r4 r1 r2
+  put db 510 r4
+  put db 509 r3
+  jal add.two
+  get r5 db 511
+  put db 511 r5
+  pop ra
+  j ra
+# registers: 9
+# lines: 25

--- a/test/cases/functions_using_push_pop.compact.ref
+++ b/test/cases/functions_using_push_pop.compact.ref
@@ -1,0 +1,7 @@
+add r2 1 2
+add r4 r2 3
+move r0 r4
+move r1 r0
+s db Setting r1
+# registers: 4
+# lines: 5

--- a/test/cases/functions_using_push_pop.py
+++ b/test/cases/functions_using_push_pop.py
@@ -1,0 +1,13 @@
+# pytrapic: use_push_pop_functions
+from stationeers_pytrapic.symbols import *
+
+
+def add_two(a, b):
+    return a + b
+
+
+def compute(x, y, z):
+    return add_two(x + y, z)
+
+
+db.Setting = compute(1, 2, 3)

--- a/test/cases/functions_using_push_pop.ref
+++ b/test/cases/functions_using_push_pop.ref
@@ -1,0 +1,27 @@
+push 1
+push 2
+push 3
+jal compute
+pop r0
+s db Setting r0
+add.two:
+  pop r7
+  pop r6
+  add r8 r6 r7
+  push r8
+  j ra
+compute:
+  pop r3
+  pop r2
+  pop r1
+  push ra
+  add r4 r1 r2
+  push r4
+  push r3
+  jal add.two
+  pop r5
+  pop ra
+  push r5
+  j ra
+# registers: 9
+# lines: 25


### PR DESCRIPTION
This is messier than I'd like, largely because pushing and popping the return address has to happen carefully and in the right order, so there's some complex logic to handle the order of operations there, especially when doing early returns.

It also uses a compiler directive to allow this behavior, leaving previous behavior the same. This is in case someone has done extra push/pop stack activity through direct manipulation such that the new handling of parameters would mess up the order. It shouldn't, logically, but who knows what games people play with the stack pointer. 

Fixes #23.