### PR TITLE
Make pytrapic output LogicType's numeric code even in non-compact mode.

### DIFF
--- a/scripts/build_enums.py
+++ b/scripts/build_enums.py
@@ -6,15 +6,21 @@ data = json.load(open("Enums.json", "r"))
 
 generated_types = set()
 
-file_code = f"from enum import IntEnum as _IntEnum\n\n"
-for collection in data.values():
+file_code = (
+    "from enum import IntEnum as _IntEnum\n\n"
+    "class _NamedIntEnum(_IntEnum):\n"
+    '    """IntEnum subclass for enums whose names IC10 understands (LogicType, LogicSlotType, LogicBatchMethod)."""\n'
+    "    pass\n\n"
+)
+for collection_name, collection in data.items():
     for enum_data in collection.values():
         name = enum_data["enumName"]
         if name in generated_types:
             continue
         generated_types.add(name)
         values = enum_data["values"]
-        file_code += f"\nclass {name}(_IntEnum):\n"
+        base = "_NamedIntEnum" if collection_name == "scriptEnums" else "_IntEnum"
+        file_code += f"\nclass {name}({base}):\n"
         for value_name, value in values.items():
             if keyword.iskeyword(value_name):
                 value_name += "_"

--- a/src/stationeers_pytrapic/types_generated.py
+++ b/src/stationeers_pytrapic/types_generated.py
@@ -1,7 +1,12 @@
 from enum import IntEnum as _IntEnum
 
 
-class LogicType(_IntEnum):
+class _NamedIntEnum(_IntEnum):
+    """IntEnum subclass for enums whose names IC10 understands (LogicType, LogicSlotType, LogicBatchMethod)."""
+    pass
+
+
+class LogicType(_NamedIntEnum):
     None_ = 0
     Power = 1
     Open = 2
@@ -286,7 +291,7 @@ class LogicType(_IntEnum):
     ContactSlotIndex = 282
 
 
-class LogicSlotType(_IntEnum):
+class LogicSlotType(_NamedIntEnum):
     None_ = 0
     Occupied = 1
     OccupantHash = 2
@@ -329,7 +334,7 @@ class LogicReagentMode(_IntEnum):
     TotalContents = 3
 
 
-class LogicBatchMethod(_IntEnum):
+class LogicBatchMethod(_NamedIntEnum):
     Average = 0
     Sum = 1
     Minimum = 2

--- a/src/stationeers_pytrapic/utils.py
+++ b/src/stationeers_pytrapic/utils.py
@@ -35,10 +35,10 @@ def set_output_mode(mode: OutputMode):
 
 
 def format_enum(enum_val) -> str | int:
-    if _output_mode == OutputMode.VERBOSE:
+    from .types_generated import _NamedIntEnum
+    if _output_mode == OutputMode.VERBOSE and isinstance(enum_val, _NamedIntEnum):
         return enum_val.name
-    else:
-        return enum_val.value
+    return enum_val.value
 
 
 _math_functions = {

--- a/test/cases/enum_mode_value.compact.ref
+++ b/test/cases/enum_mode_value.compact.ref
@@ -1,0 +1,3 @@
+s d0 3 10
+# registers: 0
+# lines: 1

--- a/test/cases/enum_mode_value.py
+++ b/test/cases/enum_mode_value.py
@@ -1,0 +1,4 @@
+from stationeers_pytrapic.symbols import *
+
+display = ConsoleLED1x2(d0)
+display.Mode = DisplayMode.String

--- a/test/cases/enum_mode_value.ref
+++ b/test/cases/enum_mode_value.ref
@@ -1,0 +1,3 @@
+s d0 Mode 10
+# registers: 0
+# lines: 1


### PR DESCRIPTION
Fix issue where LogicType's non-compact IC10 compiled output uses the value String instead of 10. However, IC10 mips code doesn't support that named type, only supporting the numeric code. This extracts a separate enum type for non-named enums (such as LogicType) and those are rendered as their value (code) regardless of whether they're using compact directive or not.

Fixes #22 