### PR TITLE
Tidy up mod deployment scripts, and make the c# setup a bit more resilient to different developer setups.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ codes
 bin
 obj
 ws
+Local.*.props

--- a/About/About.xml
+++ b/About/About.xml
@@ -2,7 +2,7 @@
   <Name>PyTrapIC - Python to IC10 Transpiler</Name>
   <Author>aproposmath</Author>
   <ModID>com.github.aproposmath.stationeers-pytrapic</ModID>
-  <Version></Version>
+  <Version>dev</Version>
   <Description>
         This mod allows you to write [b]Python[/b] instead of IC10. The Python code is converted into IC10 before it's written to the chip. It depends on the IC10 Editor mod, which replaces the in-game code editor. To use it, select "Python" as the language in the top right corner of the IC10 Editor window. Search for "pytrapic" in the Stationpedia for examples.
 

--- a/Dist.props
+++ b/Dist.props
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DistDir Condition="'$(DistDir)' == ''">dist</DistDir>
+    <ModDistDir>$(DistDir)/pytrapic</ModDistDir>
+    <PublishDistPdbs Condition="'$(PublishDistPdbs)' == ''">true</PublishDistPdbs>
+  </PropertyGroup>
+
+  <!-- Stage a copy of About/ into the build output dir before version generation.
+       Only runs on Release so Debug builds are unaffected. -->
+  <Target Name="StageAbout"
+          BeforeTargets="GenerateVersion"
+          Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <StagedAboutFiles Include="About/**/*" />
+    </ItemGroup>
+    <MakeDir Directories="$(OutputPath)About" />
+    <Copy SourceFiles="@(StagedAboutFiles)"
+          DestinationFolder="$(OutputPath)About/%(RecursiveDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Override GenerateVersion from Template/Template.props.
+       On Release: points create_version_info.py at the staged About copy.
+       On Debug: falls back to the same behavior as Template.props (source About.xml). -->
+  <Target Name="GenerateVersion" BeforeTargets="BeforeBuild">
+    <PropertyGroup>
+      <_AboutXmlPath Condition="'$(Configuration)' == 'Release'">$(OutputPath)About/About.xml</_AboutXmlPath>
+      <_AboutXmlPath Condition="'$(Configuration)' != 'Release'">About/About.xml</_AboutXmlPath>
+    </PropertyGroup>
+    <Exec Command="$(PythonExec) Template/create_version_info.py Template/VersionInfo.g.cs $(AssemblyName) $(_AboutXmlPath) $(Configuration)" />
+  </Target>
+
+  <!-- Publish dist: sources About from the staged (version-stamped) path on Release. -->
+  <Target Name="PublishDist" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+    <MakeDir Directories="$(ModDistDir)" />
+    <ItemGroup>
+      <DistDlls Include="$(OutputPath)$(AssemblyName).dll" />
+      <DistPdb Include="$(OutputPath)$(AssemblyName).pdb" Condition="'$(PublishDistPdbs)' != 'false'" />
+      <DistAbout Include="$(OutputPath)About/**/*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DistDlls)" DestinationFolder="$(ModDistDir)" />
+    <Copy SourceFiles="@(DistPdb)" DestinationFolder="$(ModDistDir)" />
+    <Copy SourceFiles="@(DistAbout)"
+          DestinationFolder="$(ModDistDir)/About/%(RecursiveDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CleanDist" AfterTargets="Clean" Condition="Exists('$(ModDistDir)')">
+    <RemoveDir Directories="$(ModDistDir)" />
+  </Target>
+</Project>

--- a/Main.csproj
+++ b/Main.csproj
@@ -3,4 +3,11 @@
   <Import Project="Main.props"/>
   <Import Project="Template/Template.props"/>
   <Import Project="Template/FindStationeers.props"/>
+  <!--
+    Load a local props file if present - this should not be checked-in, but should allow the
+    developer to add local path or tool overrides, etc.
+  -->
+  <Import Project="Local.Developer.props" Condition="Exists('Local.Developer.props')" />
+  <!-- A file to handle release into a dist directory. Loaded after Templates to override. -->
+  <Import Project="Dist.props" Condition="Exists('Dist.props')" />
 </Project>

--- a/Main.props
+++ b/Main.props
@@ -5,8 +5,9 @@
     <ModID>stationeers-pytrapic</ModID>
     <AssemblyName>PyTrapIC</AssemblyName>
     <Description>Python to IC10 Transpiler</Description>
-    <!-- Optional: Set this if it's not found automatically or you want to force a specific Stationeers directory -->
-    <StationeersDirectory />
+    <!-- Optional: Set this in Local.Developer.props if it's not found automatically or you want to force a specific Stationeers directory -->
+    <!-- <StationeersDllDir>Template/libs</StationeersDllDir> -->
+    
     <Dependencies>
       <Url>https://github.com/aproposmath/StationeersIC10Editor/releases/download/main/IC10Editor-main.zip</Url>
       <Url>https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases/download/v0.2.25/StationeersLaunchPad-client-v0.2.25.zip</Url>

--- a/README.md
+++ b/README.md
@@ -503,3 +503,60 @@ j 0
 The transpiler itself is written in Python and uses [astroid](https://pypi.org/project/astroid/) to parse python code.
 
 The web application uses [Pyodide](https://pyodide.org/) to run the transpiler in the browser. The editor is based on [monaco](https://microsoft.github.io/monaco-editor/) and uses [monaco-pyright-lsp](https://github.com/SardineFish/monaco-pyright-lsp) for code completion. No data is sent to the server, everything is running in the browser.
+
+## Developer / Contributor Setup
+
+### Python Environment
+
+The project requires **Python 3.10+**. A `.venv` is the recommended way to work locally.
+
+Create and activate the venv (first time only):
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the package in editable mode with its dependencies:
+
+```sh
+pip install -e .
+```
+
+For building wheels, generating type stubs, and running the webapp data pipeline, also install:
+
+```sh
+pip install build wheel pyright setuptools setuptools_scm
+```
+
+> **macOS note:** The system Python (e.g. Homebrew Python 3.14) is PEP 668 "externally managed" and will refuse `pip install` without `--break-system-packages`. Always use the project `.venv`.
+
+### Running Tests
+
+```sh
+pip install pytest
+pytest
+```
+
+Tests live in `test/` and compare transpiler output against `.ref` reference files.
+
+### Project Structure
+
+```
+src/stationeers_pytrapic/   # transpiler core (Python)
+test/                        # pytest test cases and reference outputs
+mod/                         # in-game C# mod (PyTrapIC.cs)
+webapp/                      # browser IDE (TypeScript + Vite)
+scripts/                     # code generation and build helpers
+pyproject.toml               # package metadata and build config
+```
+
+Version is managed by `setuptools_scm` from git tags, written to `src/stationeers_pytrapic/_version.py` at build time.
+
+### Webapp
+
+The browser IDE has its own setup steps (Node.js, data file generation). See [webapp/README.md](webapp/README.md).
+
+### C# Mod
+
+The in-game BepInEx mod has its own setup steps (.NET SDK, game DLLs, mod dependencies). See the [Developer Setup section in mod/README.md](mod/README.md#developer-setup).

--- a/mod/README.md
+++ b/mod/README.md
@@ -74,3 +74,113 @@ while True:
 
 - Limited Lua support (the first code line must be `require("stationeers_pytrapic.symbols")`)
 
+---
+
+## Developer Setup
+
+The mod is a C# BepInEx plugin built with the .NET SDK. The build system is MSBuild and lives mostly in the `Template/` git submodule at the project root.
+
+### Prerequisites
+
+- **.NET SDK 10** (see `global.json` at the repo root; `rollForward: latestMajor` means newer major versions also work)
+- **Python 3** — required by the `GenerateVersion` MSBuild target that runs before every build
+- **Stationeers** — needed to compile against the game's DLLs (see [Game DLLs](#game-dlls) below)
+
+### Clone with submodule
+
+The `Template/` directory is a git submodule. Initialise it after cloning:
+
+```sh
+# git
+git submodule update --init
+
+# jj (if using Jujutsu)
+jj git submodule update --init
+```
+
+### Game DLLs
+
+The build needs Stationeers' managed DLLs (e.g. `Assembly-CSharp.dll`). The build system tries to locate them automatically, then falls back to the checked-in stub libraries in `Template/libs/`.
+
+**Auto-detection order** (from `Template/FindStationeers.props`):
+
+| Priority | Condition |
+|----------|-----------|
+| 1 | `STATIONEERS_DIR` environment variable |
+| 2 | Default Windows Steam paths (`C:/Program Files (x86)/Steam/…`, `D:/…`, `E:/…`) |
+| 3 | Default Linux Steam paths (`~/.steam/steam/…`, `~/Steam/…`, `$STEAMROOT/…`) |
+| 4 | `StationeersDirectory` set in `Local.Developer.props` |
+| 5 | CI fallback: `Template/libs/` (used automatically when `GITHUB_ACTIONS=true`) |
+
+**macOS**: Stationeers has no macOS client, so the game DLLs are never present. The build will automatically use the checked-in stub libraries in `Template/libs/`. No extra steps needed.
+
+**Linux / Windows with non-standard Steam path**: create a `Local.Developer.props` file in the repo root (it is gitignored) to override the path:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <StationeersDllDir>/path/to/Stationeers/rocketstation_Data/Managed</StationeersDllDir>
+  </PropertyGroup>
+</Project>
+```
+
+You can also set the `STATIONEERS_DIR` environment variable to the Stationeers install root (the directory containing `rocketstation_Data/`) instead.
+
+### Download mod dependencies
+
+The mod depends on two external DLLs (the IC10 editor and StationeersLaunchPad) that are not in the repo. Download them once from the project root:
+
+```sh
+python3 Template/download_dependencies.py
+```
+
+This reads the `<Dependencies>` URLs from `Main.props` and extracts the DLLs into `Template/dependencies/`.
+
+### Building
+
+From the **repo root** (where `Main.csproj` lives):
+
+```sh
+dotnet build -c Debug Main.csproj
+```
+
+Or use the convenience script from `mod/` (also installs into BepInEx plugins):
+
+```sh
+cd mod && ./build.sh
+```
+
+`build.sh` defaults the install path to `~/.sa/Stationeers/BepInEx/plugins/`. Override it with:
+
+```sh
+STATIONEERS_MOD_DIR=/your/path/BepInEx/plugins ./build.sh
+```
+
+### IDEs
+
+Any editor with MSBuild/C# support works. Open `Main.csproj` (at the repo root) as the project file.
+
+- **JetBrains Rider** — open `Main.csproj` directly; Rider picks up NuGet sources from `NuGet.Config` automatically
+- **Visual Studio** (Windows) — open `Main.csproj`; restores NuGet packages on first build
+- **VS Code** — install the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) extension, then open the repo root folder
+
+`Local.Developer.props` is the right place for any machine-specific overrides (Stationeers path, Python executable name, etc.) so they stay out of version control. An example file to override the Python executable on systems where it is `python3` instead of `python`:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <PythonExec>python3</PythonExec>
+  </PropertyGroup>
+</Project>
+```
+
+### Building a release zip
+
+From the repo root:
+
+```sh
+cd mod && ./release.sh
+```
+
+Output: `dist/PyTrapIC.zip`, ready to unzip into `BepInEx/plugins/`.
+

--- a/mod/build.sh
+++ b/mod/build.sh
@@ -1,9 +1,21 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e
+stationeers_mod_dir=${STATIONEERS_MOD_DIR:-~/.sa/Stationeers/BepInEx/plugins}
+
+if [[ ! -f Main.csproj ]] ; then
+  echo "You must execute $(basename "$0") from the project root" ; exit 1
+fi
+
+mod_dir="${stationeers_mod_dir}/pytrapic"
+
+rm -rf bin/Debug
 
 # ~/.local/share/nvim/mason/bin/csharpier format *.cs
-# xmllint --format PyTrapIC.csproj -o PyTrapIC.csproj
-# xmllint --format PyTrapIC.props -o PyTrapIC.props
-dotnet build -c Debug PyTrapIC.csproj
+# xmllint --format Main.csproj -o Main.csproj
+# xmllint --format Main.props -o Main.props
+dotnet build -c Debug Main.csproj
 
-cp bin/Debug/net46/PyTrapIC.dll ~/.sa/Stationeers/BepInEx/scripts/
+mkdir -p "${mod_dir}/"
+cp bin/Debug/*/PyTrapIC.dll "${mod_dir}/"
+cp -r About "${mod_dir}/"
+echo "Installed PyTrapIc (Debug) into ${mod_dir}"

--- a/mod/install.sh
+++ b/mod/install.sh
@@ -1,10 +1,19 @@
-#!/bin/bash
-
-DIR=`pwd`
-rm -f *.zip
+#!/usr/bin/env bash
 set -e
-./release.sh
 
-cd ~/.sa/Stationeers/BepInEx/plugins/
-rm -rf pytrapic
-unzip $DIR/*.zip
+exec_dir=$(dirname "$0")
+
+# Might want to put the mod into the steam-visible mods dir.
+mod_dir=${STATIONEERS_MOD_DIR:-~/.sa/Stationeers/BepInEx/plugins/}
+
+if [[ ! -f "${exec_dir}/release.sh" ]] ; then
+  echo "You must execute $(basename "$0") from the project root" ; exit 1
+fi
+
+# build the release version into a dist dir
+DIST_DIR="$(pwd)/dist"
+export DIST_DIR;
+"${exec_dir}/release.sh"
+
+(cd "${mod_dir}" && rm -rf pytrapic && unzip "${DIST_DIR}"/*.zip)
+echo "PyTrapIc (Release) installed into ${mod_dir}"

--- a/mod/release.sh
+++ b/mod/release.sh
@@ -1,12 +1,12 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e
 
+if [[ ! -f Main.csproj ]]; then
+  echo "Run from project root"; exit 1
+fi
 
-dotnet build -c Release PyTrapIC.csproj
+dist_dir="${DIST_DIR:-dist}"
+dotnet clean Main.csproj
+dotnet build -c Release Main.csproj  # PublishDist target handles dist/ population
 
-rm -rf pytrapic PyTrapIC.zip
-mkdir -p pytrapic
-
-cp bin/Release/net48/PyTrapIC.dll pytrapic/
-cp -r About pytrapic/
-zip -r PyTrapIC.zip ./pytrapic
+(cd "${dist_dir}" && zip -r PyTrapIC.zip pytrapic && echo "Released to ${dist_dir}/pytrapic/")

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,93 @@
+# PyTrapIC Webapp
+
+Browser-based IDE for PyTrapIC. Write Python on the left, get IC10 assembly on the right — no server involved. The transpiler runs entirely in-browser via [Pyodide](https://pyodide.org/) (Python WASM), and the editor is [Monaco](https://microsoft.github.io/monaco-editor/) with Pyright-powered type checking via [monaco-pyright-lsp](https://github.com/SardineFish/monaco-pyright-lsp).
+
+The production build is deployed to GitHub Pages at https://aproposmath.github.io/stationeers-pytrapic.
+
+## Prerequisites
+
+- **Node.js** (v18+) and **yarn**
+- **Python 3.10+** with a working venv — needed only to generate the data files (see below)
+
+See the [root README Developer section](../README.md#developer--contributor-setup) for Python environment setup.
+
+## Setup
+
+The `webapp/data/` directory is gitignored. It holds two generated files that must exist before you can run the dev server:
+
+| File | Purpose |
+|------|---------|
+| `stationeers_pytrapic.zip` | Pyright type stubs (`.pyi` files), used by Monaco for autocompletion |
+| `stationeers_pytrapic-0.0.1-py3-none-any.whl` | The transpiler Python wheel, fetched and unpacked by Pyodide at runtime |
+
+Generate them from the repo root (with the venv active):
+
+```sh
+source .venv/bin/activate
+./scripts/build_data.sh
+```
+
+Then install frontend dependencies:
+
+```sh
+cd webapp
+yarn
+```
+
+## Running Locally
+
+```sh
+yarn dev
+```
+
+Vite starts a dev server at `http://localhost:5173` and opens it automatically. Changes to `src/` hot-reload.
+
+## Building for Production
+
+```sh
+yarn build
+```
+
+Output goes to `webapp/dist/`. This is what gets deployed to GitHub Pages (see `.github/workflows/webapp.yml`).
+
+To preview the production build locally:
+
+```sh
+yarn preview
+```
+
+## How It Works
+
+On page load (`src/index.ts`):
+
+1. `loadPyodide()` is called (script loaded from CDN in `index.html`)
+2. `stationeers_pytrapic.zip` is fetched and passed to `MonacoPyrightProvider` as type stubs
+3. Monaco editor is created with Python as the language
+4. Pyodide finishes loading; `micropip` installs `astroid` and `luaparser` from PyPI
+5. The `.whl` file is fetched and unpacked into Pyodide's in-memory filesystem
+6. Initial code is loaded from URL params, `localStorage`, or a default solar-panel example
+7. Editor changes trigger a debounced (500 ms) call to `compile_code` in Python via Pyodide
+
+The compiled IC10 is syntax-highlighted using a custom `highlight.js` language definition (`src/highlight_ic10.js`).
+
+## URL Parameters
+
+| Param | Description |
+|-------|-------------|
+| `?data=<encoded>` | Load shared code+settings (base64/compressed, encoded by `types.encode_data`) |
+| `?fileUrl=<url>` | Fetch raw Python source from a URL |
+| `?compact=1` | Force compact output mode on load |
+
+## Toolbar Options
+
+| Option | Compiler flag | Default |
+|--------|--------------|---------|
+| Comments | `original_code_as_comment` | off |
+| Compact | `compact`, `inline_functions`, `remove_labels` | off |
+| Version | `append_version` | on |
+
+## Notes
+
+- The wheel filename in `webapp/data/` is **always** `stationeers_pytrapic-0.0.1-py3-none-any.whl` regardless of actual version — this name is hardcoded in `src/index.ts`. `build_data.sh` renames the versioned wheel when copying.
+- There are no frontend tests. Testing is manual: run `yarn dev`, write Python, observe IC10 output.
+- Commented-out code in `src/index.ts` (the "reload-game" / "upload-game" buttons) was intended to integrate with a local `localhost:8080` API served by the in-game C# mod. It is not currently active.


### PR DESCRIPTION
This changes a few things in particular:

- Fixes up the mod deployment/build scripts:
  - match Main.csproj (current tools assume PyTrapIC.csproj) 
  - account for other locations for installing mods, and add some
  - error if the mod shell scripts are executed in the wrong directory. 
- Add a Dist.props that overrides some Templates release-oriented actions:
  - Moves About/* prior to editing the version in the About.xml file, so the version-controlled source is not altered during release.
  - Makes "dist" a default target for where release distributable files are built. Dist is configurable (probably overkill, but it wasn't hard)
- Add a local properties file (Local.Developer.props) which is optionally loaded, and ignored by github, so devs can add their own msbuild bits without having to check out local variations.
  - Example:
     ```xml
    <Project>
      <PropertyGroup>
        <PythonExec>python3</PythonExec>
        <StationeersDllDir>Template/libs</StationeersDllDir>
      </PropertyGroup>
    </Project>
     ```
- Should preserve existing behavior (defaults preserved from original author's setup). 